### PR TITLE
Allow "luahbtex" and "mmoptex" format names

### DIFF
--- a/source/lua-widow-control.lua
+++ b/source/lua-widow-control.lua
@@ -62,9 +62,9 @@ if format:find("cont") then -- cont-en, cont-fr, cont-nl, ...
     end
 elseif format:find("latex") then -- lualatex, lualatex-dev, ...
     latex = true
-elseif format == "luatex" then -- Plain
+elseif format == "luatex" or format == "luahbtex" then -- Plain
     plain = true
-elseif format == "optex" then -- OpTeX
+elseif format:find("optex") then -- OpTeX
     optex = true
 end
 


### PR DESCRIPTION
Commit message is reproduced below:

> For the purposes of this package "luahbtex" should behave the same as "luatex". Also allow "mmoptex" and potentially other format names through `string.find` for OpTeX. ("mmoptex" is OpTeX as distributed in the mmtex distribution).

I included `lua-widow-package` in [mmtex](https://github.com/vlasakm/mmtex). (I hope you don't mind, even  though I already managed to fail to commit the license file and because of my date based versioning scheme I can't fix it until tomorrow. Sorry about that.) And because the format there is named `mmoptex` to avoid conflicts, `lua-widow-control` would refuse to run, so I changed the format check to `string.find` instead (which should hopefully be futureproof and without collisions).

I also noticed that `luahbtex` plain format isn't allowed, so I added that as well.

[I added this patch as temporary workaround to mmtex](https://github.com/vlasakm/mmtex/commit/4c4bdbacc5f040739928c137a738dfb91026014e), though I would appreciate if you would merge either this pull request or fix the issue in any other way.

I don't know much about the topic of widows and orphans, [though it was recently discussed in the context of OpTeX](https://github.com/olsak/OpTeX/discussions/98), where I mentioned your package, which prompted me to add it to mmtex.

So thank you very much for this package and in advance for the fix!